### PR TITLE
Add AWS secrets manager

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     param_store (0.0.1)
+      aws-sdk-secretsmanager (~> 1)
       aws-sdk-ssm (~> 1)
 
 GEM
@@ -14,6 +15,9 @@ GEM
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
+    aws-sdk-secretsmanager (1.20.0)
+      aws-sdk-core (~> 3, >= 3.39.0)
+      aws-sigv4 (~> 1.0)
     aws-sdk-ssm (1.34.0)
       aws-sdk-core (~> 3, >= 3.39.0)
       aws-sigv4 (~> 1.0)

--- a/lib/param_store.rb
+++ b/lib/param_store.rb
@@ -1,10 +1,12 @@
 require 'aws-sdk-ssm'
+require 'aws-sdk-secretsmanager'
 require 'forwardable'
 
 require 'param_store/version'
 require 'param_store/wrapper'
 require 'param_store/adapters/env'
 require 'param_store/adapters/ssm'
+require 'param_store/adapters/secrets_manager'
 
 module ParamStore
   extend SingleForwardable
@@ -18,9 +20,14 @@ module ParamStore
 
   class << self
     attr_reader :adapter, :wrapper
+    attr_writer :ssm_client, :secrets_manager_client
 
     def ssm_client
-      @_ssm_client ||= Aws::SSM::Client.new
+      @ssm_client ||= Aws::SSM::Client.new
+    end
+
+    def secrets_manager_client
+      @secrets_manager_client ||= Aws::SecretsManager::Client.new
     end
 
     def adapter(adapter, **opts)
@@ -34,6 +41,8 @@ module ParamStore
         Adapters::Env
       when :aws_ssm
         Adapters::SSM
+      when :aws_secrets_manager
+        Adapters::SecretsManager
       else
         raise "Invalid adapter: #{adapter}"
       end

--- a/lib/param_store/adapters/secrets_manager.rb
+++ b/lib/param_store/adapters/secrets_manager.rb
@@ -1,0 +1,32 @@
+module ParamStore
+  module Adapters
+    class SecretsManager
+      def initialize(**_opts); end
+
+      def fetch(key, *args, version_id: nil, version_stage: nil, &block)
+        tmp = {}
+        if string = get_secret_value(key, version_id, version_stage)
+          tmp[key] = JSON.parse(string)
+        end
+        tmp.fetch(key, *args, &block)
+      end
+
+      def fetch_all(*keys, **opts); end
+
+      private
+
+      def get_secret_value(key, version_id, version_stage)
+        options = { secret_id: key }
+        options[:version_id] = version_id
+        options[:version_stage] = version_stage
+        ParamStore.secrets_manager_client.get_secret_value(options).secret_string
+      rescue Aws::SecretsManager::Errors::ResourceNotFoundException
+        # let the tmp.fetch below deal with key not found and defaults
+      end
+
+      def prepend_path(path, key)
+        "#{path || default_path}#{key}"
+      end
+    end
+  end
+end

--- a/lib/param_store/adapters/secrets_manager.rb
+++ b/lib/param_store/adapters/secrets_manager.rb
@@ -11,7 +11,11 @@ module ParamStore
         tmp.fetch(key, *args, &block)
       end
 
-      def fetch_all(*keys, **opts); end
+      def fetch_all(*keys, **opts)
+        # poor man's fetch all
+        # I couldn't find a batch get for secrets manager :/
+        keys.map { |key| fetch(key, {}, **opts) }.inject(:merge)
+      end
 
       private
 

--- a/lib/param_store/adapters/secrets_manager.rb
+++ b/lib/param_store/adapters/secrets_manager.rb
@@ -1,17 +1,23 @@
 module ParamStore
   module Adapters
     class SecretsManager
-      def initialize(**_opts); end
+      attr_reader :default_secret_id
+
+      def initialize(default_secret_id: nil)
+        @default_secret_id = default_secret_id
+      end
 
       def fetch(key, *args, secret_id: nil, version_id: nil, version_stage: nil, &block)
-        get_key = secret_id || key
+        get_key = secret_id || default_secret_id || key
 
         if cache[get_key].nil? &&
-          string = get_secret_value(get_key, version_id, version_stage)
+           string = get_secret_value(get_key, version_id, version_stage)
           cache[get_key] = JSON.parse(string)
         end
 
-        (secret_id.nil? ? cache : cache[get_key]).fetch(key, *args, &block)
+        (
+          secret_id.nil? && default_secret_id.nil? ? cache : cache[get_key]
+        ).fetch(key, *args, &block)
       end
 
       def fetch_all(*keys, **opts)

--- a/param_store.gemspec
+++ b/param_store.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'aws-sdk-secretsmanager', '~> 1'
   spec.add_dependency 'aws-sdk-ssm', '~> 1'
 
   spec.add_development_dependency 'bundler', '~> 1.16'

--- a/spec/param_store/adapters/secrets_manager_spec.rb
+++ b/spec/param_store/adapters/secrets_manager_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ParamStore::Adapters::SecretsManager do
     end
 
     context 'when secret_id' do
-      specify do
+      it 'retrieves specific keys and cache lookups' do
         expect(secrets_manager_client).to receive(
           :get_secret_value
         ).once.with(
@@ -32,6 +32,23 @@ RSpec.describe ParamStore::Adapters::SecretsManager do
 
         expect(subject.fetch('key1', secret_id: 'keys')).to eq('value1')
         expect(subject.fetch('key2', secret_id: 'keys')).to eq('value2')
+      end
+    end
+
+    context 'when a default secret_id' do
+      it 'retrieves specific keys and cache lookups' do
+        expect(secrets_manager_client).to receive(
+          :get_secret_value
+        ).once.with(
+          secret_id: 'keys',
+          version_id: nil,
+          version_stage: nil
+        ).and_return(double(secret_string: '{"key1":"value1", "key2":"value2"}'))
+
+        subject = described_class.new(default_secret_id: 'keys')
+
+        expect(subject.fetch('key1')).to eq('value1')
+        expect(subject.fetch('key2')).to eq('value2')
       end
     end
 

--- a/spec/param_store/adapters/secrets_manager_spec.rb
+++ b/spec/param_store/adapters/secrets_manager_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+RSpec.describe ParamStore::Adapters::SecretsManager do
+  let(:secrets_manager_client) { double 'Secrets Manager client' }
+
+  before do
+    allow(ParamStore).to receive(:secrets_manager_client).and_return(secrets_manager_client)
+  end
+
+  describe '#fetch' do
+    it 'retrieves a value' do
+      allow(secrets_manager_client).to receive(
+        :get_secret_value
+      ).with(
+        secret_id: 'keys',
+        version_id: nil,
+        version_stage: nil
+      ).and_return(double(secret_string: '{"key1":"value"}'))
+
+      expect(subject.fetch('keys')).to eq('key1' => 'value')
+    end
+
+    context 'when not found' do
+      before do
+        allow(ParamStore.secrets_manager_client).to receive(
+          :get_secret_value
+        ).and_raise(
+          Aws::SecretsManager::Errors::ResourceNotFoundException.new({}, 'not found')
+        )
+      end
+
+      it 'raises an error' do
+        expect { subject.fetch('not_found') }.to raise_error(KeyError)
+      end
+
+      it 'uses default value' do
+        expect(subject.fetch('not_found', 'value')).to eq('value')
+      end
+
+      it 'uses block value' do
+        expect(subject.fetch('not_found') { 'value' }).to eq('value')
+      end
+    end
+  end
+end

--- a/spec/param_store/adapters/secrets_manager_spec.rb
+++ b/spec/param_store/adapters/secrets_manager_spec.rb
@@ -20,6 +20,21 @@ RSpec.describe ParamStore::Adapters::SecretsManager do
       expect(subject.fetch('keys')).to eq('key1' => 'value')
     end
 
+    context 'when secret_id' do
+      specify do
+        expect(secrets_manager_client).to receive(
+          :get_secret_value
+        ).once.with(
+          secret_id: 'keys',
+          version_id: nil,
+          version_stage: nil
+        ).and_return(double(secret_string: '{"key1":"value1", "key2":"value2"}'))
+
+        expect(subject.fetch('key1', secret_id: 'keys')).to eq('value1')
+        expect(subject.fetch('key2', secret_id: 'keys')).to eq('value2')
+      end
+    end
+
     context 'when not found' do
       before do
         allow(ParamStore.secrets_manager_client).to receive(


### PR DESCRIPTION
### Usage

```ruby
ParamStore.adapter :aws_secrets_manager

ParamStore.fetch('my_secret')
ParamStore.copy_to_env('my_secret1', 'my_secret2', 'my_secret3')

ENV['my_secret1']

# For fetching a specific key:

ParamStore.fetch('my_key', secret_id: 'my_secret')

# Setting a default secret_id:

ParamStore.adapter :aws_secrets_manager, default_secret_id: 'my_secret'
# then 
ParamStore.fetch('my_key')
# will retrieve `my_key` within `my_secret`
```

<strike>
But I'm still unsure of this implementation. Secrets Manager returns a JSON with keys and values, feels like the usage as-is in this pull requests would be more like `ParamStore.fetch('my_key').fetch('real_wanted_key')`.


Maybe something similar to [the `path` implementation for ssm](https://github.com/phstc/param_store/blob/master/lib/param_store/adapters/ssm.rb#L10), but using `version_id` instead `ParamStore.fetch('real_wanted_key', secret_id: 'my_key')` 🤔 

```ruby
ParamStore.fetch('my_key')
# => { 'real_wanted_key' => 'value' }

ParamStore.fetch('real_wanted_key', secret_id: 'my_key')
# => 'value'
```
</strike>