### PR TITLE
Do not require aws-sdk-ssm by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 gemspec
 
 group :development, :test do
+  gem 'aws-sdk-ssm', '~> 1'
   gem 'pry-byebug'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     param_store (0.0.1)
-      aws-sdk-ssm (~> 1)
 
 GEM
   remote: https://rubygems.org/
@@ -52,6 +51,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-ssm (~> 1)
   bundler (~> 1.16)
   param_store!
   pry-byebug

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This gem is not a replacement for [dotenv](https://github.com/bkeepers/dotenv). 
 Add this line to your application's Gemfile:
 
 ```ruby
+gem 'aws-sdk-ssm', '~> 1'
 gem 'param_store'
 ```
 

--- a/lib/param_store.rb
+++ b/lib/param_store.rb
@@ -1,4 +1,3 @@
-require 'aws-sdk-ssm'
 require 'forwardable'
 
 require 'param_store/version'
@@ -33,10 +32,19 @@ module ParamStore
       when :env
         Adapters::Env
       when :aws_ssm
+        require_aws_ssm
         Adapters::SSM
       else
         raise "Invalid adapter: #{adapter}"
       end
+    end
+
+    private
+
+    def require_aws_ssm
+      require 'aws-sdk-ssm'
+    rescue LoadError
+      fail "aws_ssm requires aws-sdk-ssm to be installed separately. Please add gem 'aws-sdk-ssm' to your Gemfile"
     end
   end
 end

--- a/param_store.gemspec
+++ b/param_store.gemspec
@@ -21,8 +21,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'aws-sdk-ssm', '~> 1'
-
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'rake', '~> 10.0'
 end

--- a/spec/param_store/adapters/ssm_spec.rb
+++ b/spec/param_store/adapters/ssm_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ParamStore::Adapters::SSM do
   let(:ssm_client) { double 'SSM client' }
 
   before do
+    ParamStore.adapter :aws_ssm
     allow(ParamStore).to receive(:ssm_client).and_return(ssm_client)
   end
 


### PR DESCRIPTION
For supporting more adapters #1 and #2. `ParamStore` needs to make their dependency optional, otherwise for loading `ParamStore` we will need to load a bunch of dependencies that may not be needed.

After this change, for using SSM, it will need to be included in the Gemfile as well.

```ruby
gem 'aws-sdk-ssm', '~> 1'
gem 'param_store'
```